### PR TITLE
Fix applyProperties method for invalid or readonly attributes in Safari

### DIFF
--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -20,7 +20,10 @@ function applyProperties(node, props, previous) {
             if (isObject(propValue)) {
                 patchObject(node, props, previous, propName, propValue);
             } else {
-                node[propName] = propValue
+                try {
+                    // this is a workaround in case of invalid value or readonly propName
+                    node[propName] = propValue;
+                } catch(err) {}
             }
         }
     }


### PR DESCRIPTION
https://xohellobar.atlassian.net/browse/CE-65

Guys, it's a real mess with this `applyProperties` method. It exists in two versions: one in [vdom-serialized-patch](https://github.com/CrazyEggInc/vdom-serialized-patch/blob/master/lib/patch/applyProperties.js) repository, and another one here. They are already different, so we cannot use same source to follow DRY principle, unless we devote much time to it.

That's why I had to fork this repo. In final `req.js` file the two methods are generated, and to make sure bug in Safari disappears I have to update them both.
