### PR TITLE
Refactor apply-properties.js to synchronize it with vdom-serialized-patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-var diff = require("./diff.js")
-var patch = require("./patch.js")
-var h = require("./h.js")
-var create = require("./create-element.js")
-var VNode = require('./vnode/vnode.js')
-var VText = require('./vnode/vtext.js')
+var diff = require("./diff.js");
+var patch = require("./patch.js");
+var h = require("./h.js");
+var create = require("./create-element.js");
+var VNode = require('./vnode/vnode.js');
+var VText = require('./vnode/vtext.js');
 
 module.exports = {
     diff: diff,
@@ -12,4 +12,4 @@ module.exports = {
     create: create,
     VNode: VNode,
     VText: VText
-}
+};

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -1,100 +1,116 @@
-var isObject = require("is-object")
-var isHook = require("../vnode/is-vhook.js")
+var isObject = require('is-object');
+var isHook = require('../vnode/is-vhook');
+var isSoftSetHook = require('./is-soft-set-hook');
+var isUndefinedValue = require('./is-undefined-value');
 
-module.exports = applyProperties
+module.exports = applyProperties;
 
 function applyProperties(node, props, previous) {
-    for (var propName in props) {
-        var propValue = props[propName]
+  for (var propName in props) {
+    var propValue = props[propName];
 
-        if (propValue === undefined) {
-            removeProperty(node, propName, propValue, previous);
-        } else if (isHook(propValue)) {
-            removeProperty(node, propName, propValue, previous)
-            if (propValue.hook) {
-                propValue.hook(node,
-                    propName,
-                    previous ? previous[propName] : undefined)
-            }
-        } else {
-            if (isObject(propValue)) {
-                patchObject(node, props, previous, propName, propValue);
-            } else {
-                try {
-                    // this is a workaround in case of invalid value or readonly propName
-                    node[propName] = propValue;
-                } catch(err) {}
-            }
-        }
+    if (isUndefinedValue(propValue)) {
+      removeProperty(node, propName, propValue, previous);
+
+    } else if (isHook(propValue)) {
+      removeProperty(node, propName, propValue, previous);
+
+      if (propValue.hook) {
+        propValue.hook(node,
+          propName,
+          previous ? previous[propName] : undefined);
+      }
+
+    } else if (isSoftSetHook(propValue)) {
+      removeProperty(node, propName, propValue, previous);
+      node[propName] = propValue.value;
+
+    } else {
+      if (isObject(propValue)) {
+        patchObject(node, previous, propName, propValue);
+      } else {
+        setProperty(node, propName, propValue);
+      }
     }
+  }
 }
 
 function removeProperty(node, propName, propValue, previous) {
-    if (previous) {
-        var previousValue = previous[propName]
+  if (!previous) {
+    return;
+  }
 
-        if (!isHook(previousValue)) {
-            if (propName === "attributes") {
-                for (var attrName in previousValue) {
-                    node.removeAttribute(attrName)
-                }
-            } else if (propName === "style") {
-                for (var i in previousValue) {
-                    node.style[i] = ""
-                }
-            } else if (typeof previousValue === "string") {
-                node[propName] = ""
-            } else {
-                node[propName] = null
-            }
-        } else if (previousValue.unhook) {
-            previousValue.unhook(node, propName, propValue)
-        }
+  var previousValue = previous[propName];
+
+  if (!isHook(previousValue)) {
+    if (propName === "attributes") {
+      for (var attrName in previousValue) {
+        node.removeAttribute(attrName);
+      }
+    } else if (propName === "style") {
+      for (var i in previousValue) {
+        node.style[i] = "";
+      }
+    } else if (typeof previousValue === "string") {
+      node[propName] = "";
+    } else {
+      node[propName] = null;
     }
+
+  } else if (previousValue.unhook) {
+    previousValue.unhook(node, propName, propValue);
+  }
 }
 
-function patchObject(node, props, previous, propName, propValue) {
-    var previousValue = previous ? previous[propName] : undefined
+function setProperty(node, propName, value) {
+  // this is a workaround in case of invalid value or readonly propName
+  try {
+    node[propName] = value;
+  } catch(err) {}
+}
 
-    // Set attributes
-    if (propName === "attributes") {
-        for (var attrName in propValue) {
-            var attrValue = propValue[attrName]
+function patchObject(node, previous, propName, propValue) {
+  var previousValue = previous ? previous[propName] : undefined
 
-            if (attrValue === undefined) {
-                node.removeAttribute(attrName)
-            } else {
-                node.setAttribute(attrName, attrValue)
-            }
-        }
+  // Set attributes
+  if (propName === "attributes") {
+    for (var attrName in propValue) {
+      var attrValue = propValue[attrName];
 
-        return
+      if (attrValue === undefined) {
+        node.removeAttribute(attrName);
+      } else {
+        node.setAttribute(attrName, attrValue);
+      }
     }
 
-    if(previousValue && isObject(previousValue) &&
-        getPrototype(previousValue) !== getPrototype(propValue)) {
-        node[propName] = propValue
-        return
-    }
+    return;
+  }
 
-    if (!isObject(node[propName])) {
-        node[propName] = {}
-    }
+  if (previousValue && isObject(previousValue) &&
+    getPrototype(previousValue) !== getPrototype(propValue)) {
+    node[propName] = propValue;
+    return;
+  }
 
-    var replacer = propName === "style" ? "" : undefined
+  if (!isObject(node[propName])) {
+    node[propName] = {}
+  }
 
-    for (var k in propValue) {
-        var value = propValue[k]
-        node[propName][k] = (value === undefined) ? replacer : value
-    }
+  var replacer = propName === "style" ? "" : undefined;
+
+  for (var k in propValue) {
+    var value = propValue[k];
+    node[propName][k] = isUndefinedValue(value) ? replacer : value;
+  }
 }
 
 function getPrototype(value) {
-    if (Object.getPrototypeOf) {
-        return Object.getPrototypeOf(value)
-    } else if (value.__proto__) {
-        return value.__proto__
-    } else if (value.constructor) {
-        return value.constructor.prototype
-    }
+  // getPrototypeOf shim for older browsers
+  /* istanbul ignore else */
+  if (Object.getPrototypeOf) {
+    return Object.getPrototypeOf(value)
+  } else {
+    return value.__proto__ || value.constructor.prototype;
+  }
 }

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -1,7 +1,7 @@
 var isObject = require('is-object');
 var isHook = require('../vnode/is-vhook');
 var isSoftSetHook = require('./is-soft-set-hook');
-var isUndefinedValue = require('./is-undefined-value');
+var undefinedValue = require('./undefined-value');
 
 module.exports = applyProperties;
 
@@ -9,7 +9,7 @@ function applyProperties(node, props, previous) {
   for (var propName in props) {
     var propValue = props[propName];
 
-    if (isUndefinedValue(propValue)) {
+    if (undefinedValue.isUndefined(propValue)) {
       removeProperty(node, propName, propValue, previous);
 
     } else if (isHook(propValue)) {
@@ -101,7 +101,7 @@ function patchObject(node, previous, propName, propValue) {
 
   for (var k in propValue) {
     var value = propValue[k];
-    node[propName][k] = isUndefinedValue(value) ? replacer : value;
+    node[propName][k] = undefinedValue.isUndefined(value) ? replacer : value;
   }
 }
 

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -23,7 +23,7 @@ function applyProperties(node, props, previous) {
 
     } else if (isSoftSetHook(propValue)) {
       removeProperty(node, propName, propValue, previous);
-      node[propName] = propValue.value;
+      setProperty(node, propName, propValue);
 
     } else {
       if (isObject(propValue)) {
@@ -52,9 +52,9 @@ function removeProperty(node, propName, propValue, previous) {
         node.style[i] = "";
       }
     } else if (typeof previousValue === "string") {
-      node[propName] = "";
+      setProperty(node, propName, "");
     } else {
-      node[propName] = null;
+      setProperty(node, propName, null);
     }
 
   } else if (previousValue.unhook) {

--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -23,7 +23,7 @@ function applyProperties(node, props, previous) {
 
     } else if (isSoftSetHook(propValue)) {
       removeProperty(node, propName, propValue, previous);
-      node[propName] = propValue.value;
+      setProperty(node, propName, propValue.value);
 
     } else {
       if (isObject(propValue)) {

--- a/vdom/is-soft-set-hook.js
+++ b/vdom/is-soft-set-hook.js
@@ -1,0 +1,5 @@
+module.exports = isSoftSetHook;
+
+function isSoftSetHook(x) {
+  return x && typeof x === 'object' && typeof x.value !== 'undefined';
+}

--- a/vdom/is-undefined-value.js
+++ b/vdom/is-undefined-value.js
@@ -1,8 +1,8 @@
 //Magic value to map keys with a value of undefined to in JSON form since JSON
 //won't preserve those.  This is necessary because in patches, the removal of
 //a property is represented by the property name mapped to undefined
-function isUndefinedHook(value) {
+function isUndefinedValue(value) {
     return value === undefined || value === '____UnDeFiNeD____';
 }
 
-module.exports = isUndefinedHook;
+module.exports = isUndefinedValue;

--- a/vdom/is-undefined-value.js
+++ b/vdom/is-undefined-value.js
@@ -1,0 +1,8 @@
+//Magic value to map keys with a value of undefined to in JSON form since JSON
+//won't preserve those.  This is necessary because in patches, the removal of
+//a property is represented by the property name mapped to undefined
+function isUndefinedHook(value) {
+    return value === undefined || value === '____UnDeFiNeD____';
+}
+
+module.exports = isUndefinedHook;

--- a/vdom/undefined-value.js
+++ b/vdom/undefined-value.js
@@ -1,8 +1,13 @@
 //Magic value to map keys with a value of undefined to in JSON form since JSON
 //won't preserve those.  This is necessary because in patches, the removal of
 //a property is represented by the property name mapped to undefined
-function isUndefinedValue(value) {
-    return value === undefined || value === '____UnDeFiNeD____';
+var UNDEFINED = '____UnDeFiNeD____';
+
+function isUndefined(value) {
+    return value === undefined || value === UNDEFINED;
 }
 
-module.exports = isUndefinedValue;
+module.exports = {
+    isUndefined: isUndefined,
+    undefinedConst: UNDEFINED
+};


### PR DESCRIPTION
I'm refactoring apply-properties.js. Now it is synchronized with the corresponding file from vdom-serialized-patch repo so we can remove it from there and avoid code duplication.
Also moving "____UnDeFiNeD____" string hook from vdom-as-json repo to this one, because it is used in applyProperties method. All other repos depend on this one so they can use its files.

I know it's a big mess with these repositories, so trying to structurize them a bit.

Related PRs:
https://github.com/CrazyEggInc/vdom-serialized-patch/pull/7