### PR TITLE
Use undefinedValue to check attributes

### DIFF
--- a/vdom/apply-properties.js
+++ b/vdom/apply-properties.js
@@ -77,7 +77,7 @@ function patchObject(node, previous, propName, propValue) {
     for (var attrName in propValue) {
       var attrValue = propValue[attrName];
 
-      if (attrValue === undefined) {
+      if (undefinedValue.isUndefined(attrValue)) {
         node.removeAttribute(attrName);
       } else {
         node.setAttribute(attrName, attrValue);


### PR DESCRIPTION
I noticed this issue when running tests in vdom-serialized-patch repo:
      AssertionError: expected '<div data-something-else="true"></div>' to equal '<div data-something="____UnDeFiNeD____" data-something-else="true"></div>'
      + expected - actual

      -<div data-something-else="true"></div>
      +<div data-something="____UnDeFiNeD____" data-something-else="true"></div>

Attribute value "____UnDeFiNeD____" was treated as string instead of as a sign to remove the attribute.